### PR TITLE
Re-enable cron jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Docker CI
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch
-  #schedule:
-  #  - cron: '0 0 * * 0'
+  schedule:
+    - cron: '0 0 * * 0'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
~~Go builds currently fail on kreato/builder due to the package relying on a new version of nyaa. Re-enabling cron jobs would fix this.~~
No longer applicable